### PR TITLE
Fix VB Option Strict build errors

### DIFF
--- a/Source/PolicyPlus/EditSetting.vb
+++ b/Source/PolicyPlus/EditSetting.vb
@@ -83,7 +83,7 @@
                         addControl(textPres.ID, label, "")
                     Case "decimalTextBox" ' Numeric spin box or a plain text box restricted to numbers
                         Dim decimalTextPres As NumericBoxPresentationElement = pres
-                        Dim numeric As DecimalPolicyElement = elemDict(pres.ID)
+                        Dim numeric As DecimalPolicyElement = DirectCast(elemDict(pres.ID), DecimalPolicyElement)
                         Dim newControl As Control
                         If decimalTextPres.HasSpinner Then
                             newControl = New NumericUpDown With {
@@ -109,7 +109,7 @@
                         addControl(pres.ID, newControl, decimalTextPres.Label)
                     Case "textBox" ' Simple text box
                         Dim textboxPres As TextBoxPresentationElement = pres
-                        Dim text As TextPolicyElement = elemDict(pres.ID)
+                        Dim text As TextPolicyElement = DirectCast(elemDict(pres.ID), TextPolicyElement)
                         Dim textbox As New TextBox With {
                             .Width = ExtraOptionsTable.Width * 0.75,
                             .Text = textboxPres.DefaultValue,
@@ -129,7 +129,7 @@
                         addControl(pres.ID, checkbox, "")
                     Case "comboBox" ' Text box with suggestions, not tested because it's not used in any default ADML
                         Dim comboPres As ComboBoxPresentationElement = pres
-                        Dim text As TextPolicyElement = elemDict(pres.ID)
+                        Dim text As TextPolicyElement = DirectCast(elemDict(pres.ID), TextPolicyElement)
                         Dim combobox As New ComboBox With {.DropDownStyle = ComboBoxStyle.DropDown}
                         combobox.MaxLength = text.MaxLength
                         combobox.Width = ExtraOptionsTable.Width * 0.75
@@ -143,7 +143,7 @@
                         Dim dropdownPres As DropDownPresentationElement = pres
                         Dim combobox As New ComboBox With {.DropDownStyle = ComboBoxStyle.DropDownList}
                         combobox.Sorted = Not dropdownPres.NoSort
-                        Dim enumElem As EnumPolicyElement = elemDict(pres.ID)
+                        Dim enumElem As EnumPolicyElement = DirectCast(elemDict(pres.ID), EnumPolicyElement)
                         Dim itemId As Integer = 0
                         Using g = combobox.CreateGraphics ' Figure out how wide it should be, and add entries
                             Dim maxWidth = combobox.Width
@@ -160,7 +160,7 @@
                         addControl(pres.ID, combobox, dropdownPres.Label)
                     Case "listBox" ' Button to launch a grid view editor
                         Dim listPres As ListPresentationElement = pres
-                        Dim list As ListPolicyElement = elemDict(pres.ID)
+                        Dim list As ListPolicyElement = DirectCast(elemDict(pres.ID), ListPolicyElement)
                         Dim button As New Button With {
                             .UseVisualStyleBackColor = True,
                             .Text = "Edit..."

--- a/Source/PolicyPlus/InspectPolicyElements.vb
+++ b/Source/PolicyPlus/InspectPolicyElements.vb
@@ -123,23 +123,23 @@
                 If elem.ElementType <> "list" Then elemNode.Nodes.Add("Registry value: " & elem.RegistryValue).ImageIndex = 13
                 Select Case elem.ElementType
                     Case "decimal"
-                        Dim decimalElem As DecimalPolicyElement = elem
+                        Dim decimalElem As DecimalPolicyElement = DirectCast(elem, DecimalPolicyElement)
                         elemNode.Nodes.Add("Minimum: " & decimalElem.Minimum).ImageIndex = 35 ' Down arrow
                         elemNode.Nodes.Add("Maximum: " & decimalElem.Maximum).ImageIndex = 6
                         If decimalElem.StoreAsText Then elemNode.Nodes.Add("Stored as text").ImageIndex = 33 ' Letters
                         elemNode.Nodes.Add("Required: " & If(decimalElem.Required, "yes", "no")).ImageIndex = 32 ' Exclamation
                         If decimalElem.NoOverwrite Then elemNode.Nodes.Add("Soft").ImageIndex = 34 ' Soft speaker
                     Case "boolean"
-                        Dim booleanElem As BooleanPolicyElement = elem
+                        Dim booleanElem As BooleanPolicyElement = DirectCast(elem, BooleanPolicyElement)
                         addList(booleanElem.AffectedRegistry, elemNode.Nodes, True)
                     Case "text"
-                        Dim textElem As TextPolicyElement = elem
+                        Dim textElem As TextPolicyElement = DirectCast(elem, TextPolicyElement)
                         elemNode.Nodes.Add("Maximum length: " & textElem.MaxLength).ImageIndex = 6
                         If textElem.RegExpandSz Then elemNode.Nodes.Add("Stored as expandable string").ImageIndex = 36 ' Letters with arrow
                         elemNode.Nodes.Add("Required: " & If(textElem.Required, "yes", "no")).ImageIndex = 32
                         If textElem.NoOverwrite Then elemNode.Nodes.Add("Soft").ImageIndex = 34
                     Case "list"
-                        Dim listElem As ListPolicyElement = elem
+                        Dim listElem As ListPolicyElement = DirectCast(elem, ListPolicyElement)
                         If listElem.UserProvidesNames Then
                             elemNode.Nodes.Add("User provides value names").ImageIndex = 13
                         ElseIf listElem.HasPrefix Then
@@ -150,7 +150,7 @@
                         If listElem.RegExpandSz Then elemNode.Nodes.Add("Stored as expandable strings").ImageIndex = 36
                         elemNode.Nodes.Add("Preserve existing values: " & If(listElem.NoPurgeOthers, "yes", "no")).ImageIndex = 34
                     Case "enum"
-                        Dim enumElem As EnumPolicyElement = elem
+                        Dim enumElem As EnumPolicyElement = DirectCast(elem, EnumPolicyElement)
                         elemNode.Nodes.Add("Required: " & If(enumElem.Required, "yes", "no")).ImageIndex = 32
                         Dim itemsNode = elemNode.Nodes.Add(enumElem.Items.Count & " choices")
                         itemsNode.ImageIndex = 26

--- a/Source/PolicyPlus/ListEditor.vb
+++ b/Source/PolicyPlus/ListEditor.vb
@@ -8,12 +8,12 @@
         EntriesDatagrid.Rows.Clear()
         If Data IsNot Nothing Then
             If TwoColumn Then
-                Dim dict As Dictionary(Of String, String) = Data
+                Dim dict As Dictionary(Of String, String) = DirectCast(Data, Dictionary(Of String, String))
                 For Each kv In dict
                     EntriesDatagrid.Rows.Add(kv.Key, kv.Value)
                 Next
             Else
-                Dim list As List(Of String) = Data
+                Dim list As List(Of String) = DirectCast(Data, List(Of String))
                 For Each entry In list
                     EntriesDatagrid.Rows.Add("", entry)
                 Next

--- a/Source/PolicyPlus/PolicyProcessing.vb
+++ b/Source/PolicyPlus/PolicyProcessing.vb
@@ -48,7 +48,7 @@
                         presentElements += 1
                     End If
                 ElseIf elem.ElementType = "boolean" Then
-                    Dim booleanElem As BooleanPolicyElement = elem
+                    Dim booleanElem As BooleanPolicyElement = DirectCast(elem, BooleanPolicyElement)
                     If PolicySource.WillDeleteValue(elemKey, elem.RegistryValue) Then
                         deletedElements += 1 ' Implicit checkboxes are deleted when the policy is disabled
                     Else
@@ -140,12 +140,12 @@
                 Case "decimal"
                     state.Add(elem.ID, CUInt(PolicySource.GetValue(elemKey, elem.RegistryValue)))
                 Case "boolean"
-                    Dim booleanElem As BooleanPolicyElement = elem
+                    Dim booleanElem As BooleanPolicyElement = DirectCast(elem, BooleanPolicyElement)
                     state.Add(elem.ID, GetRegistryListState(PolicySource, booleanElem.AffectedRegistry, elemKey, elem.RegistryValue))
                 Case "text"
                     state.Add(elem.ID, PolicySource.GetValue(elemKey, elem.RegistryValue))
                 Case "list"
-                    Dim listElem As ListPolicyElement = elem
+                    Dim listElem As ListPolicyElement = DirectCast(elem, ListPolicyElement)
                     If listElem.UserProvidesNames Then ' Keys matter, use a dictionary
                         Dim entries As New Dictionary(Of String, String)
                         For Each value In PolicySource.GetValueNames(elemKey)
@@ -169,7 +169,7 @@
                     End If
                 Case "enum"
                     ' Determine which option has results that match the Registry
-                    Dim enumElem As EnumPolicyElement = elem
+                    Dim enumElem As EnumPolicyElement = DirectCast(elem, EnumPolicyElement)
                     Dim selectedIndex As Integer = -1
                     For n = 0 To enumElem.Items.Count - 1
                         Dim enumItem = enumElem.Items(n)
@@ -237,11 +237,11 @@
                 If elem.ElementType <> "list" Then addReg(elemKey, elem.RegistryValue)
                 Select Case elem.ElementType
                     Case "boolean"
-                        Dim booleanElem As BooleanPolicyElement = elem
+                        Dim booleanElem As BooleanPolicyElement = DirectCast(elem, BooleanPolicyElement)
                         addSingleList(booleanElem.AffectedRegistry.OnValueList, elemKey)
                         addSingleList(booleanElem.AffectedRegistry.OffValueList, elemKey)
                     Case "enum"
-                        Dim enumElem As EnumPolicyElement = elem
+                        Dim enumElem As EnumPolicyElement = DirectCast(elem, EnumPolicyElement)
                         For Each e In enumElem.Items
                             addSingleList(e.ValueList, elemKey)
                         Next
@@ -305,14 +305,14 @@
                         Dim optionData = Options(elem.ID)
                         Select Case elem.ElementType
                             Case "decimal"
-                                Dim decimalElem As DecimalPolicyElement = elem
+                                Dim decimalElem As DecimalPolicyElement = DirectCast(elem, DecimalPolicyElement)
                                 If decimalElem.StoreAsText Then
                                     PolicySource.SetValue(elemKey, elem.RegistryValue, CStr(optionData), Microsoft.Win32.RegistryValueKind.String)
                                 Else
                                     PolicySource.SetValue(elemKey, elem.RegistryValue, CUInt(optionData), Microsoft.Win32.RegistryValueKind.DWord)
                                 End If
                             Case "boolean"
-                                Dim booleanElem As BooleanPolicyElement = elem
+                                Dim booleanElem As BooleanPolicyElement = DirectCast(elem, BooleanPolicyElement)
                                 Dim checkState As Boolean = optionData
                                 If booleanElem.AffectedRegistry.OnValue Is Nothing And checkState Then
                                     PolicySource.SetValue(elemKey, elem.RegistryValue, 1UI, Microsoft.Win32.RegistryValueKind.DWord)
@@ -322,11 +322,11 @@
                                 End If
                                 setList(booleanElem.AffectedRegistry, elemKey, elem.RegistryValue, checkState)
                             Case "text"
-                                Dim textElem As TextPolicyElement = elem
+                                Dim textElem As TextPolicyElement = DirectCast(elem, TextPolicyElement)
                                 Dim regType = If(textElem.RegExpandSz, Microsoft.Win32.RegistryValueKind.ExpandString, Microsoft.Win32.RegistryValueKind.String)
                                 PolicySource.SetValue(elemKey, elem.RegistryValue, optionData, regType)
                             Case "list"
-                                Dim listElem As ListPolicyElement = elem
+                                Dim listElem As ListPolicyElement = DirectCast(elem, ListPolicyElement)
                                 If Not listElem.NoPurgeOthers Then PolicySource.ClearKey(elemKey)
                                 If optionData Is Nothing Then Continue For
                                 Dim regType = If(listElem.RegExpandSz, Microsoft.Win32.RegistryValueKind.ExpandString, Microsoft.Win32.RegistryValueKind.String)
@@ -345,7 +345,7 @@
                                     Loop
                                 End If
                             Case "enum"
-                                Dim enumElem As EnumPolicyElement = elem
+                                Dim enumElem As EnumPolicyElement = DirectCast(elem, EnumPolicyElement)
                                 Dim selItem = enumElem.Items(optionData)
                                 setValue(elemKey, elem.RegistryValue, selItem.Value)
                                 setSingleList(selItem.ValueList, elemKey)
@@ -363,7 +363,7 @@
                         If elem.ElementType = "list" Then
                             PolicySource.ClearKey(elemKey)
                         ElseIf elem.ElementType = "boolean" Then
-                            Dim booleanElem As BooleanPolicyElement = elem
+                            Dim booleanElem As BooleanPolicyElement = DirectCast(elem, BooleanPolicyElement)
                             If booleanElem.AffectedRegistry.OffValue IsNot Nothing Or booleanElem.AffectedRegistry.OffValueList IsNot Nothing Then
                                 ' Non-implicit checkboxes get their "off" value set when the policy is disabled
                                 setList(booleanElem.AffectedRegistry, elemKey, elem.RegistryValue, False)

--- a/Source/PolicyPlus/PolicySource.vb
+++ b/Source/PolicyPlus/PolicySource.vb
@@ -310,11 +310,11 @@ Public Class PolFile
             Return ped
         End Function
         Public Function AsBinary() As Byte()
-            Return Data.Clone
+            Return CType(Data.Clone(), Byte())
         End Function
         Public Shared Function FromBinary(Binary As Byte(), Optional Kind As RegistryValueKind = RegistryValueKind.Binary) As PolEntryData
             Dim ped As New PolEntryData With {.Kind = Kind}
-            ped.Data = Binary.Clone
+            ped.Data = CType(Binary.Clone(), Byte())
             Return ped
         End Function
         Public Function AsArbitrary() As Object

--- a/Source/PolicyPlus/RegFile.vb
+++ b/Source/PolicyPlus/RegFile.vb
@@ -82,7 +82,7 @@ Public Class RegFile
                         Dim indexOfClosingParen = data.IndexOf(")"c)
                         Dim curHexLine As String
                         If indexOfClosingParen <> -1 Then
-                            value.Kind = Integer.Parse(data.Substring(4, indexOfClosingParen - 4), Globalization.NumberStyles.HexNumber)
+                            value.Kind = CType(Integer.Parse(data.Substring(4, indexOfClosingParen - 4), Globalization.NumberStyles.HexNumber), RegistryValueKind)
                             curHexLine = data.Substring(indexOfClosingParen + 2)
                         Else
                             value.Kind = RegistryValueKind.Binary

--- a/Source/PolicyPlus/SpolFile.vb
+++ b/Source/PolicyPlus/SpolFile.vb
@@ -92,31 +92,37 @@
                     Dim newObj As Object
                     If valueText.StartsWith("#") Then
                         newObj = CInt(valueText.Substring(1))
-                    ElseIf UInteger.TryParse(valueText, 0) Then
-                        newObj = CUInt(valueText)
-                    ElseIf Boolean.TryParse(valueText, False) Then
-                        newObj = CBool(valueText)
-                    ElseIf valueText.StartsWith("'") And valueText.EndsWith("'") Then
-                        newObj = valueText.Substring(1, valueText.Length - 2)
-                    ElseIf valueText.StartsWith("""") And valueText.EndsWith("""") Then
-                        newObj = getAllStrings(valueText, """").ToArray
-                    ElseIf valueText = "None" Then
-                        newObj = Array.CreateInstance(GetType(String), 0)
-                    ElseIf valueText = "[" Then
-                        Dim entries As New List(Of List(Of String))
-                        Do Until Trim(peekLine()) = "]"
-                            entries.Add(getAllStrings(nextLine(), """"))
-                        Loop
-                        nextLine() ' Skip the closing bracket
-                        If entries.Count = 0 Then
-                            newObj = Nothing ' PolicyProcessing will ignore an empty list element
-                        ElseIf entries(0).Count = 1 Then
-                            newObj = entries.Select(Function(l) l(0)).ToList
-                        Else
-                            newObj = entries.ToDictionary(Function(l) l(0), Function(l) l(1))
-                        End If
                     Else
-                        Throw New Exception("Unknown option data format.")
+                        Dim parsedUInt As UInteger
+                        If UInteger.TryParse(valueText, parsedUInt) Then
+                            newObj = parsedUInt
+                        Else
+                            Dim parsedBool As Boolean
+                            If Boolean.TryParse(valueText, parsedBool) Then
+                                newObj = parsedBool
+                            ElseIf valueText.StartsWith("'") And valueText.EndsWith("'") Then
+                                newObj = valueText.Substring(1, valueText.Length - 2)
+                            ElseIf valueText.StartsWith("""") And valueText.EndsWith("""") Then
+                                newObj = getAllStrings(valueText, """").ToArray
+                            ElseIf valueText = "None" Then
+                                newObj = Array.CreateInstance(GetType(String), 0)
+                            ElseIf valueText = "[" Then
+                                Dim entries As New List(Of List(Of String))
+                                Do Until Trim(peekLine()) = "]"
+                                    entries.Add(getAllStrings(nextLine(), """"))
+                                Loop
+                                nextLine() ' Skip the closing bracket
+                                If entries.Count = 0 Then
+                                    newObj = Nothing ' PolicyProcessing will ignore an empty list element
+                                ElseIf entries(0).Count = 1 Then
+                                    newObj = entries.Select(Function(l) l(0)).ToList
+                                Else
+                                    newObj = entries.ToDictionary(Function(l) l(0), Function(l) l(1))
+                                End If
+                            Else
+                                Throw New Exception("Unknown option data format.")
+                            End If
+                        End If
                     End If
                     singlePolicy.ExtraOptions.Add(optionParts(0), newObj)
                 Loop


### PR DESCRIPTION
## Summary
- fix explicit conversions for list editor data
- avoid Object conversions in registry helpers
- cast policy element subtypes explicitly
- correct SPOL parsing to use TryParse variables
- cast enumeration values when reading Reg files

## Testing
- `xbuild Source/PolicyPlus/PolicyPlus.vbproj /property:Configuration=Release`

------
https://chatgpt.com/codex/tasks/task_e_684ef0979380832484de3cd90f65d2cc